### PR TITLE
Removed surrounding quotes for raw string types

### DIFF
--- a/SharpPad.VSCode/src/escape.ts
+++ b/SharpPad.VSCode/src/escape.ts
@@ -1,0 +1,4 @@
+export default function escape(str: string): string
+{
+  return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}

--- a/SharpPad.VSCode/src/formatters/DataFormatter.ts
+++ b/SharpPad.VSCode/src/formatters/DataFormatter.ts
@@ -38,7 +38,7 @@ export default class DataFormatter
             */
             if (target.$type === 'html' && typeof target.$html === 'string')
             {
-                return new RawFormatProvider(target, true);
+                return new RawFormatProvider(target.$html, true);
             }
 
             /*

--- a/SharpPad.VSCode/src/formatters/DataFormatter.ts
+++ b/SharpPad.VSCode/src/formatters/DataFormatter.ts
@@ -33,6 +33,15 @@ export default class DataFormatter
             }
 
             /*
+                If the target has $type=html and has the corresponding
+                $html property, then we accept it as raw HTML input.
+            */
+            if (target.$type === 'html' && typeof target.$html === 'string')
+            {
+                return new RawFormatProvider(target, true);
+            }
+
+            /*
                 If the target has a $type property, and it's a DumpContainer, then
                 it's the outer wrapper for a dump, so we recursively call the formatter
                 for the value within.
@@ -76,6 +85,6 @@ export default class DataFormatter
             We let RawFormatProvider handle pure null values, or anything else
             we don't recognize.
         */
-        return new RawFormatProvider(target);
+        return new RawFormatProvider(target, false);
     }
 }

--- a/SharpPad.VSCode/src/formatters/DumpContainerFormatProvider.ts
+++ b/SharpPad.VSCode/src/formatters/DumpContainerFormatProvider.ts
@@ -3,6 +3,7 @@ import DataFormatter from './DataFormatter'
 import TypeNameParser from '../parsers/TypeNameParser'
 import TypeName from '../parsers/TypeName'
 import DumpContainer from '../DumpContainer'
+import escape from '../escape'
 import { format } from 'util';
 
 export type DumpSourceStyle = "show" | "hide";
@@ -37,11 +38,11 @@ export default class DumpContainerFormatProvider implements IFormatProvider
         {
             if (this._container.title)
             {
-                builder = `<h2 class="dumpTitle">${this._container.title}</h2>`;
+                builder = `<h2 class="dumpTitle">${escape(this._container.title)}</h2>`;
             }
             else if (this._sourceStyle == "show" && this._container.source)
             {
-                builder = `<h2 class="dumpTitle">${this._container.source}</h2>`;
+                builder = `<h2 class="dumpTitle">${escape(this._container.source)}</h2>`;
             }
 
             if (this._showTime)

--- a/SharpPad.VSCode/src/formatters/GridFormatProvider.ts
+++ b/SharpPad.VSCode/src/formatters/GridFormatProvider.ts
@@ -1,9 +1,9 @@
 import IFormatProvider from './IFormatProvider'
 import DataFormatter from './DataFormatter'
 import TypeNameParser from '../parsers/TypeNameParser'
-
 import TypeName from '../parsers/TypeName'
 import {TypeNameStyle} from '../parsers/TypeName'
+import escape from '../escape'
 
 export default class GridFormatProvider implements IFormatProvider
 {
@@ -39,7 +39,7 @@ export default class GridFormatProvider implements IFormatProvider
         if (this._style != "none")
         {
             build += `<h4 class='clickable'>
-                <span class='typeName'>${this._type.toString(this._style)}</span>
+                <span class='typeName'>${escape(this._type.toString(this._style))}</span>
                 <span class='count'>(${this._objCollection.length} items)</span>
                 <span class='collapse'></span>
             </h4>`;
@@ -56,7 +56,7 @@ export default class GridFormatProvider implements IFormatProvider
         {
             if (property != "$values")
             {
-                build += `<th>${property}</th>`;
+                build += `<th>${escape(property)}</th>`;
             }
         }
 

--- a/SharpPad.VSCode/src/formatters/ObjectFormatProvider.ts
+++ b/SharpPad.VSCode/src/formatters/ObjectFormatProvider.ts
@@ -1,7 +1,7 @@
 import IFormatProvider from './IFormatProvider'
 import DataFormatter from './DataFormatter'
 import TypeNameParser from '../parsers/TypeNameParser'
-
+import escape from '../escape'
 import TypeName from '../parsers/TypeName'
 import {TypeNameStyle} from '../parsers/TypeName'
 

--- a/SharpPad.VSCode/src/formatters/ObjectFormatProvider.ts
+++ b/SharpPad.VSCode/src/formatters/ObjectFormatProvider.ts
@@ -39,7 +39,7 @@ export default class ObjectFormatProvider implements IFormatProvider
             {
                 let formatter = DataFormatter.getFormatter(this._targetObj[property]);
 
-                build += `<tr><th class='propName'>${property}</th><td class='equals'>=</td><td>${formatter.formatToHtml()}</td></tr>`;
+                build += `<tr><th class='propName'>${escape(property)}</th><td class='equals'>=</td><td>${formatter.formatToHtml()}</td></tr>`;
             }
         }
 

--- a/SharpPad.VSCode/src/formatters/RawFormatProvider.ts
+++ b/SharpPad.VSCode/src/formatters/RawFormatProvider.ts
@@ -30,7 +30,6 @@ export default class RawFormatProvider implements IFormatProvider
             if (typeof this._rawData === "string")
             {
                 classes.push('string');
-                display = `"${display}"`;
             }
 
             if (typeof this._rawData === "number")

--- a/SharpPad.VSCode/src/formatters/RawFormatProvider.ts
+++ b/SharpPad.VSCode/src/formatters/RawFormatProvider.ts
@@ -30,6 +30,7 @@ export default class RawFormatProvider implements IFormatProvider
             if (typeof this._rawData === "string")
             {
                 classes.push('string');
+                display = `"${display}"`;
             }
 
             if (typeof this._rawData === "number")

--- a/SharpPad.VSCode/src/formatters/RawFormatProvider.ts
+++ b/SharpPad.VSCode/src/formatters/RawFormatProvider.ts
@@ -1,4 +1,5 @@
 import IFormatProvider from './IFormatProvider'
+import escape from '../escape'
 
 export default class RawFormatProvider implements IFormatProvider
 {
@@ -30,7 +31,7 @@ export default class RawFormatProvider implements IFormatProvider
             if (typeof this._rawData === "string")
             {
                 classes.push('string');
-                display = `"${display}"`;
+                display = `"${escape(display)}"`;
             }
 
             if (typeof this._rawData === "number")

--- a/SharpPad.VSCode/src/formatters/RawFormatProvider.ts
+++ b/SharpPad.VSCode/src/formatters/RawFormatProvider.ts
@@ -4,8 +4,9 @@ import escape from '../escape'
 export default class RawFormatProvider implements IFormatProvider
 {
     private _rawData: any;
+    private _isHtml: boolean;
 
-    constructor(rawData: any)
+    constructor(rawData: any, isHtml: boolean)
     {
         if (rawData === null || rawData === undefined)
         {
@@ -15,6 +16,8 @@ export default class RawFormatProvider implements IFormatProvider
         {
             this._rawData = rawData;
         }
+
+        this._isHtml = isHtml;
     }
 
     formatToHtml(): string
@@ -30,8 +33,15 @@ export default class RawFormatProvider implements IFormatProvider
         {
             if (typeof this._rawData === "string")
             {
-                classes.push('string');
-                display = `"${escape(display)}"`;
+                if (this._isHtml) 
+                {
+                    classes.push('html');
+                }
+                else
+                {
+                    classes.push('string');
+                    display = `"${escape(display)}"`;
+                }
             }
 
             if (typeof this._rawData === "number")


### PR DESCRIPTION
I tried sending a raw string as the payload in an attempt to display custom HTML, but the quotes are a problem here. Because the format is raw, it would be better for the caller to decide if they want to include surrounding quotes for strings.

![image](https://user-images.githubusercontent.com/12145268/36627398-5c14af5e-1942-11e8-9875-e82d3e537a19.png)

Would my proposed change cause any breaks to existing features?