### PR TITLE
Added node http client

### DIFF
--- a/SharpPad.Node/dump.js
+++ b/SharpPad.Node/dump.js
@@ -110,6 +110,12 @@ function convertToObject(value) {
 function getJSON(obj) {
   obj = simplify(obj)
 
+  if (typeof obj === 'number'
+    || typeof obj === 'string'
+    || typeof obj === 'boolean') {
+    return obj
+  }
+
   if (obj instanceof Date) {
     return {
       $type: 'Date, node.js',
@@ -227,12 +233,12 @@ function lineOf(trace) {
         return reject()
       }
 
-      site.sourceContext(1, (error, { line }) => {
+      site.sourceContext(1, (error, result) => {
         if (error) {
           return reject(error)
         }
 
-        resolve(trimLine(line))
+        resolve(trimLine(result.line))
       })
     })
   })

--- a/SharpPad.Node/dump.js
+++ b/SharpPad.Node/dump.js
@@ -246,6 +246,10 @@ function lineOf(trace) {
 
 function dump(data, title) {
   const value = getJSON(data)
+  if (!dump.source) {
+    return dumpInternal(value, title)
+  }
+
   return lineOf(new Error())
     .then(source => {
       return dumpInternal(value, title, source)
@@ -257,6 +261,10 @@ function dump(data, title) {
 
 function dumpSelf(title) {
   const value = getJSON(this)
+  if (!dump.source) {
+    return dumpInternal(value, title)
+  }
+
   return lineOf(new Error())
     .then(source => {
       return dumpInternal(value, title, source)
@@ -313,6 +321,7 @@ dump.html = function html(htmlString, title) {
 }
 
 dump.port = 5255
+dump.source = true
 
 Object.prototype.dump = dumpSelf
 Number.prototype.dump = dumpSelf

--- a/SharpPad.Node/dump.js
+++ b/SharpPad.Node/dump.js
@@ -1,0 +1,313 @@
+const http = require('http')
+const stackman = require('stackman')()
+
+function sendData(data, port) {
+  const options = {
+    hostname: `localhost`,
+    port: port,
+    path: '/',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(data)
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(options, resolve)
+    req.on('error', e => {
+      console.error(e)
+      reject(e)
+    })
+
+    req.write(data)
+    req.end()
+  })
+}
+
+function sendClear(port) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`http://localhost:${port}/clear`, resolve)
+    req.on('error', e => {
+      console.error(e)
+      reject(e)
+    })
+  })
+}
+
+// Serialize requests even if they are not awaited.
+const queue = []
+
+function consume() {
+  if (queue.length === 0) {
+    return
+  }
+
+  const item = queue[0]
+  let promise
+  if (item.clear) {
+    promise = sendClear(item.port)
+  } else {
+    promise = sendData(item.data, item.port)
+  }
+
+  return promise
+    .then(() => {
+      item.resolve()
+      queue.shift()
+      consume()
+    })
+    .catch(e => {
+      console.error(e)
+      item.reject()
+      queue.shift()
+      consume()
+    })
+}
+
+function getConstructorName(obj) {
+  const ctor = obj && obj.constructor && obj.constructor.name
+  if (ctor) {
+    return ctor
+  }
+
+  const str = (obj.prototype ? obj.prototype.constructor : obj.constructor).toString()
+  const match = str.match(/function\s(\w*)/)
+  if (!match) {
+    return 'Function'
+  }
+
+  const cname = match[1]
+  const aliases = ['', 'anonymous', 'Anonymous']
+  return aliases.indexOf(cname) > -1 ? 'Function' : cname
+}
+
+function simplify(value) {
+  if (typeof value === 'undefined' || value === null) {
+    return null
+  }
+
+  const ctor = value.constructor
+  if (ctor === Number
+    || ctor === String
+    || ctor === Boolean
+    || ctor === Symbol) {
+    return value.valueOf()
+  } else {
+    return value
+  }
+}
+
+function convertToObject(value) {
+  value = simplify(value)
+  if (value && typeof value === 'object') {
+    return getJSON(value)
+  } else {
+    return { value }
+  }
+}
+
+function getJSON(obj) {
+  obj = simplify(obj)
+
+  if (obj instanceof Date) {
+    return {
+      $type: 'Date, node.js',
+      utc: obj.toUTCString()
+    }
+  }
+
+  if (obj instanceof RegExp) {
+    return {
+      $type: 'RegExp, node.js',
+      pattern: obj.toString()
+    }
+  }
+
+  if (typeof obj === 'symbol') {
+    const str = obj.toString()
+    const key = str.substring(7, str.length - 1)
+    if (key.length) {
+      return {
+        $type: 'Symbol, node.js',
+        key
+      }
+    } else {
+      return {
+        $type: 'Symbol, node.js'
+      }
+    }
+  }
+
+  if (Array.isArray(obj)) {
+    let values = obj
+    if (obj.some(item => item && typeof item === 'object')) {
+      let exemplar = {}
+      obj.forEach(item => {
+        Object.keys(convertToObject(item)).forEach(key => {
+          exemplar[key] = null
+        })
+      })
+
+      const [first, ...rest] = obj
+      exemplar = {
+        ...exemplar,
+        ...convertToObject(first),
+        $type: 'Object, node.js'
+      }
+
+      values = [exemplar, ...rest.map(convertToObject)]
+    }
+
+    return {
+      $type: 'Array, node.js',
+      $values: values
+    }
+  }
+
+  if (obj && typeof obj === 'object') {
+    return Object.keys(obj).reduce((acc, key) => {
+      acc[key] = getJSON(obj[key])
+      return acc
+    }, { $type: getConstructorName(obj) + ', node.js' })
+  }
+
+  // Everything else is itself.
+  return obj
+}
+
+function dumpInternal(value, title, source) {
+  return new Promise((resolve, reject) => {
+    queue.push({
+      resolve,
+      reject,
+      port: dump.port,
+      data: JSON.stringify({
+        $type: 'DumpContainer, node.js',
+        $value: value,
+        title,
+        source
+      }) // store a snapshot of current state
+    })
+
+    if (queue.length === 1) {
+      consume()
+    }
+  })
+}
+
+function trimLine(line) {
+  line = line.trim()
+  let index = line.indexOf('await ')
+  if (index === 0) {
+    line = line.substr(6)
+  }
+
+  index = line.indexOf('.dump(')
+  if (index !== -1) {
+    line = line.substr(0, index)
+  }
+
+  return line
+}
+
+function lineOf(trace) {
+  return new Promise((resolve, reject) => {
+    stackman.callsites(trace, (error, callsites) => {
+      if (error) {
+        return reject(error)
+      }
+
+      const site = callsites[1]
+      if (!site) {
+        return reject()
+      }
+
+      site.sourceContext(1, (error, { line }) => {
+        if (error) {
+          return reject(error)
+        }
+
+        resolve(trimLine(line))
+      })
+    })
+  })
+}
+
+function dump(data, title) {
+  const value = getJSON(data)
+  return lineOf(new Error())
+    .then(source => {
+      return dumpInternal(value, title, source)
+    })
+    .catch(() => {
+      return dumpInternal(value, title)
+    })
+}
+
+function dumpSelf(title) {
+  const value = getJSON(this)
+  return lineOf(new Error())
+    .then(source => {
+      return dumpInternal(value, title, source)
+    })
+    .catch(() => {
+      return dumpInternal(value, title)
+    })
+}
+
+dump.clear = function clear() {
+  return new Promise((resolve, reject) => {
+    if (queue.length > 1) {
+      const items = queue.splice(1, queue.length - 1)
+      items.forEach(item => item.resolve())
+    }
+
+    queue.push({
+      resolve,
+      reject,
+      port: dump.port,
+      clear: true
+    })
+
+    if (queue.length === 1) {
+      consume()
+    }
+  })
+}
+
+dump.html = function html(htmlString, title) {
+  if (typeof htmlString !== 'string') {
+    throw new Error('Invalid HTML string.')
+  }
+
+  return new Promise((resolve, reject) => {
+    queue.push({
+      resolve,
+      reject,
+      port: dump.port,
+      data: JSON.stringify({
+        $type: 'DumpContainer, node.js',
+        $value: {
+          $type: 'html',
+          $html: htmlString
+        },
+        title
+      })
+    })
+
+    if (queue.length === 1) {
+      consume()
+    }
+  })
+}
+
+dump.port = 5255
+
+Object.prototype.dump = dumpSelf
+Number.prototype.dump = dumpSelf
+String.prototype.dump = dumpSelf
+Boolean.prototype.dump = dumpSelf
+Symbol.prototype.dump = dumpSelf
+
+module.exports = dump

--- a/SharpPad.Node/dump.js
+++ b/SharpPad.Node/dump.js
@@ -213,6 +213,10 @@ function trimLine(line) {
 
 function lineOf(trace) {
   return new Promise((resolve, reject) => {
+    if (!trace && !trace.stack) {
+      return reject()
+    }
+
     stackman.callsites(trace, (error, callsites) => {
       if (error) {
         return reject(error)

--- a/SharpPad.Node/dump.js
+++ b/SharpPad.Node/dump.js
@@ -116,6 +116,10 @@ function getJSON(obj) {
     return obj
   }
 
+  if (obj && obj.$dump) {
+    return obj.$dump()
+  }
+
   if (obj instanceof Date) {
     return {
       $type: 'Date, node.js',

--- a/SharpPad.Node/package.json
+++ b/SharpPad.Node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sharp-pad",
+  "version": "0.1.0",
+  "description": "",
+  "main": "dump.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "stackman": "^3.0.1"
+  }
+}


### PR DESCRIPTION
Syntax is as follows:

```js
const dump = require('./dump') // need to add it to npm

// port, which defaults to 5255
dump.port = 7000

// Calling the function directly
dump(anything)
dump(anything, 'Title')

// Prototypes are extended to support .dump()
[1, 2, 3].dump();
'123'.dump();
(123).dump();
true.dump();
new Date().dump();
/123/.dump();
Symbol('123').dump();
({ a: 1, b: 2, c: 3 }).dump();
[{ a: 1, b: 3, c: { d: 4, f: 6 } }, { a: 3, b: 4, c: 2 }, { a: 2, b: [1, 2, 3], c: 3 }].dump();

class Person {
  constructor(name, age) {
    this.name = name
    this.age = age
  }
}

new Person('Test', 25).dump()

// clears output
dump.clear()

// outputs raw HTML
dump.html('<a href="https://google.com">Click me</a>')
```

Note: every call returns a promise, but you don't need to await those. Objects are snapshotted in the time of calling and are added to an internal queue. This ensures that requests arrive in order and also spares you from writing `await`s everywhere. Because node does not terminate until the event queue is drained, you will not face the problem of termination before writes are flushed. That said, it's not 100% tested and has room for improvements.

I left package.json with default values for you to fill out. If you don't like publishing this as a package I can do it in a separate project. But if you can, please consider the other pull request that deals with the HTML output. My ultimate goal is being able to dump node-rendered react components, which would be amazing:

```js
dump(<div>
  Your name: <input type='text' />
</div>)
```