### PR TITLE
Extension public api

### DIFF
--- a/SharpPad.VSCode/src/extension.ts
+++ b/SharpPad.VSCode/src/extension.ts
@@ -16,12 +16,15 @@ let previewUri = vscode.Uri.parse('sharppad://authority/sharppad');
 let config: Config;
 let server: SharpPadServer;
 
-function showWindow(success = (_) => {})
+function showWindow(success = (_) => {}, raiseEvent = true)
 {
     vscode.commands
         .executeCommand('vscode.previewHtml', previewUri, vscode.ViewColumn.Two, 'SharpPad')
         .then(success, (reason) => vscode.window.showErrorMessage(reason));
-    events.emit('showWindow');
+
+    if (raiseEvent) {
+        events.emit('showWindow');
+    }
 }
 
 function loadConfig()
@@ -104,18 +107,20 @@ export function activate(context: vscode.ExtensionContext)
     context.subscriptions.push(registration, disposable);
 
     return {
-      showWindow: () => {
-        showWindow();
+      showWindow: (raiseEvent = false) => {
+        showWindow(undefined, raiseEvent);
       },
       
-      dump: (data) => {
+      dump: (data, raiseEvent = false) => {
         provider.addAndUpdate(previewUri, DataFormatter.getFormatter(data));
         events.emit('dump', data);
       },
 
-      clear: () => {
+      clear: (raiseEvent = false) => {
         provider.clear(previewUri);
-        events.emit('clear');
+        if (raiseEvent) {
+          events.emit('clear');
+        }
       },
 
       events

--- a/SharpPad.VSCode/src/extension.ts
+++ b/SharpPad.VSCode/src/extension.ts
@@ -95,6 +95,20 @@ export function activate(context: vscode.ExtensionContext)
 
     context.subscriptions.push(registration, disposable);
 
+    return {
+      showWindow: () => {
+        showWindow();
+      },
+      
+      dump: (data) => {
+        provider.addAndUpdate(previewUri, DataFormatter.getFormatter(data));
+      },
+
+      clear: () => {
+        provider.clear(previewUri);
+      }
+    }
+
     //vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], ".NET Core Launch (console)");
 }
 

--- a/SharpPad.VSCode/src/extension.ts
+++ b/SharpPad.VSCode/src/extension.ts
@@ -111,18 +111,32 @@ export function activate(context: vscode.ExtensionContext)
           showWindow(undefined, raiseEvent);
       },
       
-      dump: (data, raiseEvent = false) => {
-          provider.addAndUpdate(previewUri, DataFormatter.getFormatter(data));
+      dump: (data: any, update = true, raiseEvent = false) => {
+          if (update) {
+              provider.addAndUpdate(previewUri, DataFormatter.getFormatter(data));
+          } else {
+              provider.add(DataFormatter.getFormatter(data));
+          }
+
           if (raiseEvent) {
               events.emit('dump', data);
           }
       },
 
-      clear: (raiseEvent = false) => {
-          provider.clear(previewUri);
+      clear: (update = true, raiseEvent = false, message = '') => {
+          if (update) {
+              provider.clear(previewUri, message);
+          } else {
+              provider.clearWithoutUpdate(message);
+          }
+
           if (raiseEvent) {
               events.emit('clear');
           }
+      },
+
+      update: () => {
+          provider.update(previewUri);
       },
 
       events

--- a/SharpPad.VSCode/src/extension.ts
+++ b/SharpPad.VSCode/src/extension.ts
@@ -108,19 +108,21 @@ export function activate(context: vscode.ExtensionContext)
 
     return {
       showWindow: (raiseEvent = false) => {
-        showWindow(undefined, raiseEvent);
+          showWindow(undefined, raiseEvent);
       },
       
       dump: (data, raiseEvent = false) => {
-        provider.addAndUpdate(previewUri, DataFormatter.getFormatter(data));
-        events.emit('dump', data);
+          provider.addAndUpdate(previewUri, DataFormatter.getFormatter(data));
+          if (raiseEvent) {
+              events.emit('dump', data);
+          }
       },
 
       clear: (raiseEvent = false) => {
-        provider.clear(previewUri);
-        if (raiseEvent) {
-          events.emit('clear');
-        }
+          provider.clear(previewUri);
+          if (raiseEvent) {
+              events.emit('clear');
+          }
       },
 
       events

--- a/SharpPad.VSCode/src/extension.ts
+++ b/SharpPad.VSCode/src/extension.ts
@@ -110,10 +110,12 @@ export function activate(context: vscode.ExtensionContext)
       
       dump: (data) => {
         provider.addAndUpdate(previewUri, DataFormatter.getFormatter(data));
+        events.emit('dump', data);
       },
 
       clear: () => {
         provider.clear(previewUri);
+        events.emit('clear');
       },
 
       events

--- a/SharpPad.VSCode/src/padview.ts
+++ b/SharpPad.VSCode/src/padview.ts
@@ -63,6 +63,14 @@ export default class PadViewContentProvider implements vscode.TextDocumentConten
         this.update(uri);
     }
 
+    public clearWithoutUpdate(message: string = "") {
+        this._formatters = [];
+        if (message)
+        {
+            this._defaultMessage = message;
+        }
+    }
+
     public clear(uri: vscode.Uri, message: string = "")
     {
         this._formatters = [];


### PR DESCRIPTION
VS code extensions allow you to [export a public API](https://code.visualstudio.com/docs/extensionAPI/vscode-api#_extensions) which can be used from other extensions. In this PR I have exposed the following elements:

`dump(data)` - Dump data.
`clear()` - Clears the console.
`showWindow()` - Show the window.
`events` - An EventEmitter that emits `'dump'`, `'clear'`, and `'showWindow'` events, to which other extensions can subscribe.

I needed this feature because I'm creating an extension that synchronizes output through network.